### PR TITLE
Add support for negation in Datalog rules and queries

### DIFF
--- a/Include/TL/AST.hpp
+++ b/Include/TL/AST.hpp
@@ -86,6 +86,12 @@ struct DatalogAtom {
     SourceLocation loc{};
 };
 
+// Negated Datalog atom: represents `not Atom(...)` in rule/query bodies
+struct DatalogNegation {
+    DatalogAtom atom;
+    SourceLocation loc{};
+};
+
 // Guarded clause: expression with optional guard condition
 struct GuardedClause {
     ExprPtr expr;                  // The expression to evaluate
@@ -124,7 +130,7 @@ struct Query {
     // Additionally, for Datalog queries, we may allow a conjunction of atoms and comparisons.
     std::variant<TensorRef, DatalogAtom> target;
     // If non-empty, represents a conjunctive query of atoms/conditions; the first element is usually the same as `target` when `target` holds a DatalogAtom.
-    std::vector<std::variant<DatalogAtom, DatalogCondition>> body;
+    std::vector<std::variant<DatalogAtom, DatalogNegation, DatalogCondition>> body;
     SourceLocation loc{};
 };
 
@@ -132,7 +138,7 @@ struct DatalogFact { Identifier relation; std::vector<StringLiteral> constants; 
 
 struct DatalogCondition { ExprPtr lhs; std::string op; ExprPtr rhs; SourceLocation loc{}; };
 
-struct DatalogRule { DatalogAtom head; std::vector<std::variant<DatalogAtom, DatalogCondition>> body; SourceLocation loc{}; };
+struct DatalogRule { DatalogAtom head; std::vector<std::variant<DatalogAtom, DatalogNegation, DatalogCondition>> body; SourceLocation loc{}; };
 
 using Statement = std::variant<TensorEquation, FileOperation, Query, DatalogFact, DatalogRule, FixedPointLoop>;
 

--- a/Include/TL/Runtime/DatalogEngine.hpp
+++ b/Include/TL/Runtime/DatalogEngine.hpp
@@ -106,7 +106,7 @@ private:
      * @param out Output stream
      */
     void execDatalogQuery(const DatalogAtom& atom,
-                          const std::vector<std::variant<DatalogAtom, DatalogCondition>>& body,
+                          const std::vector<std::variant<DatalogAtom, DatalogNegation, DatalogCondition>>& body,
                           std::ostream& out);
 
     /**

--- a/Source/AST.cpp
+++ b/Source/AST.cpp
@@ -141,8 +141,9 @@ std::string toString(const Statement& st) {
             oss << ')';
             return oss.str();
         }
-        static std::string bodyElemToString(const std::variant<DatalogAtom, DatalogCondition>& e) {
+        static std::string bodyElemToString(const std::variant<DatalogAtom, DatalogNegation, DatalogCondition>& e) {
             if (std::holds_alternative<DatalogAtom>(e)) return datalogAtomToString(std::get<DatalogAtom>(e));
+            if (std::holds_alternative<DatalogNegation>(e)) return std::string("not ") + datalogAtomToString(std::get<DatalogNegation>(e).atom);
             const auto& c = std::get<DatalogCondition>(e);
             return toString(*c.lhs) + " " + c.op + " " + toString(*c.rhs);
         }


### PR DESCRIPTION
- Introduced `DatalogNegation` for representing negated atoms.
- Updated rule and query evaluators to handle negation (`not`, `!`, `¬`).
- Extended parser and lexer to recognize negation keywords.
- Added unit tests for negation functionality in rules and queries.

closes #7 