### PR TITLE
Support numeric constants in Datalog facts and queries

### DIFF
--- a/Include/TL/AST.hpp
+++ b/Include/TL/AST.hpp
@@ -171,7 +171,7 @@ struct Query {
     SourceLocation loc{};
 };
 
-struct DatalogFact { Identifier relation; std::vector<StringLiteral> constants; SourceLocation loc{}; };
+struct DatalogFact { Identifier relation; std::vector<std::variant<StringLiteral, NumberLiteral>> constants; SourceLocation loc{}; };
 
 struct DatalogCondition { ExprPtr lhs; std::string op; ExprPtr rhs; SourceLocation loc{}; };
 

--- a/Source/AST.cpp
+++ b/Source/AST.cpp
@@ -182,7 +182,12 @@ std::string toString(const Statement& st) {
             std::ostringstream oss; oss << f.relation.name << '(';
             for (size_t i = 0; i < f.constants.size(); ++i) {
                 if (i) oss << ",";
-                oss << f.constants[i].text; // constants stored as strings without quotes
+                // constants can be StringLiteral or NumberLiteral
+                if (auto* sl = std::get_if<StringLiteral>(&f.constants[i])) {
+                    oss << sl->text;
+                } else if (auto* nl = std::get_if<NumberLiteral>(&f.constants[i])) {
+                    oss << nl->text;
+                }
             }
             oss << ')';
             return oss.str();

--- a/Source/Runtime/DatalogEngine.cpp
+++ b/Source/Runtime/DatalogEngine.cpp
@@ -22,7 +22,11 @@ bool DatalogEngine::addFact(const DatalogFact& fact) {
             oss << "Added fact: " << fact.relation.name << "(";
             for (size_t i = 0; i < fact.constants.size(); ++i) {
                 if (i) oss << ", ";
-                oss << fact.constants[i].text;
+                if (auto* sl = std::get_if<StringLiteral>(&fact.constants[i])) {
+                    oss << sl->text;
+                } else if (auto* nl = std::get_if<NumberLiteral>(&fact.constants[i])) {
+                    oss << nl->text;
+                }
             }
             oss << ")";
             debugLog(oss.str());

--- a/Source/VM.cpp
+++ b/Source/VM.cpp
@@ -88,7 +88,13 @@ bool Environment::addFact(const std::string &relation, const std::vector<std::st
 bool Environment::addFact(const DatalogFact &f) {
   std::vector<std::string> tuple;
   tuple.reserve(f.constants.size());
-  for (const auto &c : f.constants) tuple.push_back(c.text);
+  for (const auto &c : f.constants) {
+    if (auto* sl = std::get_if<StringLiteral>(&c)) {
+      tuple.push_back(sl->text);
+    } else if (auto* nl = std::get_if<NumberLiteral>(&c)) {
+      tuple.push_back(nl->text);
+    }
+  }
   return addFact(f.relation.name, tuple);
 }
 


### PR DESCRIPTION
Added support for Float/numeric constants in Datalog facts and queries.

closes #14 