### PR TITLE
Fix CMake URL parsing for libtorch download

### DIFF
--- a/cmake/FetchLibTorch.cmake
+++ b/cmake/FetchLibTorch.cmake
@@ -45,7 +45,7 @@ message(STATUS "URL: ${LIBTORCH_URL}")
 
 FetchContent_Declare(
     libtorch
-    URL ${LIBTORCH_URL}
+    URL "${LIBTORCH_URL}"
     DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
 


### PR DESCRIPTION
  Quote LIBTORCH_URL variable in FetchContent_Declare to ensure
  compatibility with CMake 3.22.6 used in GitHub Actions.
  Fixes 'URL is a path (invalid in a list)' error.